### PR TITLE
feature/survey-rents-edit-modal-render

### DIFF
--- a/R/mod_survey_parking.R
+++ b/R/mod_survey_parking.R
@@ -358,7 +358,7 @@ mod_survey_parking_server <- function(
 
         rhandsontable::rhandsontable(
           data = tbl_data,
-          contextMenu = TRUE,
+          contextMenu = FALSE,
           rowHeaders = NULL,
           stretchH = "all",
           width = "100%",

--- a/R/mod_survey_rents.R
+++ b/R/mod_survey_rents.R
@@ -271,11 +271,10 @@ mod_survey_rents_server <- function(
             "Square Feet per Bed",
             "Available"
           ),
-          contextMenu = TRUE,
           stretchH = "all",
           width = "100%"
         ) |>
-          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE) |>
+          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE, contextMenu = FALSE) |>
           rhandsontable::hot_col(1, type = "dropdown", source = get_survey_choices("floorplans", "floorplan_type"), halign = "htCenter") |>
           rhandsontable::hot_col(2, halign = "htCenter") |>
           rhandsontable::hot_col(3, type = "numeric", halign = "htCenter") |>
@@ -307,11 +306,10 @@ mod_survey_rents_server <- function(
             "Market Rent per Bed",
             "Market Rent per Square Foot"
           ),
-          contextMenu = TRUE,
           stretchH = "all",
           width = "100%"
         ) |>
-          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE) |>
+          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE, contextMenu = FALSE) |>
           rhandsontable::hot_col(1, type = "dropdown", source = get_survey_choices("floorplans", "floorplan_type"), halign = "htCenter") |>
           rhandsontable::hot_col(2, halign = "htCenter") |>
           rhandsontable::hot_col(3, type = "numeric", halign = "htCenter", format = "$0,0.00") |>
@@ -355,11 +353,10 @@ mod_survey_rents_server <- function(
             "Expenses Trash Valet",
             "Expenses Parking"
           ),
-          contextMenu = TRUE,
           stretchH = "all",
           width = "100%"
         ) |>
-          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE) |>
+          rhandsontable::hot_table(highlightCol = TRUE, highlightRow = TRUE, contextMenu = FALSE) |>
           rhandsontable::hot_col(1, type = "dropdown", source = get_survey_choices("floorplans", "floorplan_type"), halign = "htCenter") |>
           rhandsontable::hot_col(2, halign = "htCenter") |>
           rhandsontable::hot_col(3, type = "numeric", halign = "htCenter", format = "$0,0.00") |>

--- a/R/mod_survey_rents.R
+++ b/R/mod_survey_rents.R
@@ -289,6 +289,8 @@ mod_survey_rents_server <- function(
       output$modal_rents <- rhandsontable::renderRHandsontable({
         shiny::req(rents_data())
 
+        modal_tab_reset()
+
         tbl_data <- rents_data() |>
           dplyr::select(
             "floorplan_type",
@@ -319,6 +321,8 @@ mod_survey_rents_server <- function(
 
       output$modal_concessions_expenses <- rhandsontable::renderRHandsontable({
         shiny::req(rents_data())
+
+        modal_tab_reset()
 
         tbl_data <- rents_data() |>
           dplyr::select(
@@ -374,12 +378,16 @@ mod_survey_rents_server <- function(
 
       # edit --------------------------------------------------------------------
 
+      modal_tab_reset <- shiny::reactiveVal(0)
+
       shiny::observeEvent(edit_survey_section(), {
         shiny::req(session$userData$selected_survey_tab())
 
         if (session$userData$selected_survey_tab() != "nav_rents") {
           return()
         }
+
+        modal_tab_reset(modal_tab_reset() + 1)
 
         iv$initialize()
         iv$enable()
@@ -390,7 +398,7 @@ mod_survey_rents_server <- function(
         modal_rents_hot <- rhandsontable::rHandsontableOutput(ns("modal_rents")) |>
           htmltools::tagAppendAttributes(.cssSelector = "div", style = "width: 100%; height: auto;")
         modal_concessions_expenses_hot <- rhandsontable::rHandsontableOutput(ns("modal_concessions_expenses")) |>
-          htmltools::tagAppendAttributes(.cssSelector = "div", style = "width: 100%; height: auto;")
+          htmltools::tagAppendAttributes(.cssSelector = ".rhandsontable", style = "width: 100% !IMPORTANT; height: auto !IMPORTANT;")
 
         shiny::showModal(
           shiny::modalDialog(
@@ -398,7 +406,7 @@ mod_survey_rents_server <- function(
               style = "font-size: 1.5rem; font-weight: bold;",
               "Edit Rents"
             ),
-            size = "l",
+            size = "xl",
             easyClose = FALSE,
             footer = htmltools::tagList(
               shiny::actionButton(
@@ -443,15 +451,8 @@ mod_survey_rents_server <- function(
               bslib::nav_panel(
                 title = "Concessions & Expenses",
                 icon = bsicons::bs_icon("currency-dollar"),
-                value = ns("concessions_expenses"),
-                bslib::layout_columns(
-                  col_widths = c(12),
-                  htmltools::tags$div(
-                    class = "hot-container",
-                    style = "width: 100%; padding: 10px;",
-                    modal_concessions_expenses_hot
-                  )
-                )
+                value = "concessions_expenses",
+                modal_concessions_expenses_hot
               )
             ),
             # changes preview
@@ -595,8 +596,7 @@ mod_survey_rents_server <- function(
           }
 
           changes_list
-        }
-      )
+        })
 
       output$changes_preview <- shiny::renderUI({
         shiny::req(changes())

--- a/R/mod_survey_rents.R
+++ b/R/mod_survey_rents.R
@@ -82,7 +82,7 @@ mod_survey_rents_ui <- function(id) {
         bslib::card_body(
           reactable::reactableOutput(
             ns("rents_by_floorplan")
-          )
+          ) |> with_loader()
         ),
         bslib::card_footer(
           shiny::textOutput(ns("rents_by_floorplan_last_updated"))
@@ -106,7 +106,7 @@ mod_survey_rents_ui <- function(id) {
         bslib::card_body(
           reactable::reactableOutput(
             ns("avg_rents_by_unit_type")
-          )
+          ) |> with_loader()
         ),
         bslib::card_footer(
           shiny::textOutput(ns("avg_rents_last_updated"))


### PR DESCRIPTION
* Fix `Cancel` button functionality for `Edit` modal
* Fix `rhandsontable` render bug
* Increase `Edit` modal size to `xl`
* Remove `contextMenu`s to disable adding/removing rows
* Commented out logic for confirmed `Cancel Edit` with unsaved changes